### PR TITLE
Quick update

### DIFF
--- a/src/vg/civcraft/mc/mercury/venus/VenusHandler.java
+++ b/src/vg/civcraft/mc/mercury/venus/VenusHandler.java
@@ -32,7 +32,7 @@ public class VenusHandler implements ServiceHandler{
 	@Override
 	public void sendMessage(String destination, String message, String... channels) {
 		for (String channel: channels)
-			service.sendMessage(destination, channel, message);
+			service.sendMessage(destination, message, channel);
 	}
 
 	// Venus doesn't need channels registered.

--- a/src/vg/civcraft/mc/mercury/venus/VenusService.java
+++ b/src/vg/civcraft/mc/mercury/venus/VenusService.java
@@ -16,7 +16,6 @@ import vg.civcraft.mc.mercury.events.AsyncPluginBroadcastMessageEvent;
 
 public class VenusService implements Runnable{
 	
-	private static MercuryPlugin plugin;
 	private Socket socket;
 	private DataInputStream input;
 	private PrintWriter output;


### PR DESCRIPTION
Made the Venus binding of Mercury handle messages from plugins in the same order as the other bindings will, so there shouldn't be any changes if switched to a different message handler. Not sure why the order was swapped for venus, i probably did it, but its fixed.
