### PR TITLE
Self disabling when offline

### DIFF
--- a/src/vg/civcraft/mc/mercury/MercuryPlugin.java
+++ b/src/vg/civcraft/mc/mercury/MercuryPlugin.java
@@ -24,6 +24,8 @@ public class MercuryPlugin extends JavaPlugin{
 		instance = this;
 	    saveDefaultConfig();
 	    handleService();
+	    if (handler == null)
+	    	return;
 	    new MercuryAPI();
 	    addServerToServerList();
 	    Bukkit.getScheduler().runTaskTimer(this, new Runnable(){
@@ -39,7 +41,8 @@ public class MercuryPlugin extends JavaPlugin{
 	}
 	
 	public void onDisable(){
-		handler.destory();
+		if (handler != null)
+			handler.destory();
 	}
 	
 	public void addChannels(JavaPlugin plugin, String... channels){
@@ -62,6 +65,11 @@ public class MercuryPlugin extends JavaPlugin{
 			handler = new RabbitHandler();
 		else if (service.equalsIgnoreCase("venus"))
 			handler = new VenusHandler();
+			
+		if (handler.isEnabled() == false){
+			handler = null;
+			getServer().getPluginManager().disablePlugin(this);
+		}
 	}
 	
 	private void pingService(){

--- a/src/vg/civcraft/mc/mercury/ServiceHandler.java
+++ b/src/vg/civcraft/mc/mercury/ServiceHandler.java
@@ -4,7 +4,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public interface ServiceHandler {
-
+	public boolean isEnabled();
 	public void pingService();
 	public void addServerToServerList();
 	public void sendMessage(String server, String message, String... channels);

--- a/src/vg/civcraft/mc/mercury/jedis/JedisHandler.java
+++ b/src/vg/civcraft/mc/mercury/jedis/JedisHandler.java
@@ -27,6 +27,12 @@ public class JedisHandler implements ServiceHandler{
 	}
 	
 	@Override
+	public boolean isEnabled() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
 	public void pingService() {
 		Jedis j = pool.getResource();
 		String x = j.get("servers");

--- a/src/vg/civcraft/mc/mercury/rabbitmq/RabbitHandler.java
+++ b/src/vg/civcraft/mc/mercury/rabbitmq/RabbitHandler.java
@@ -23,6 +23,12 @@ public class RabbitHandler implements ServiceHandler{
 	}
 	
 	@Override
+	public boolean isEnabled() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
 	public void pingService() {
 		
 	}

--- a/src/vg/civcraft/mc/mercury/venus/VenusHandler.java
+++ b/src/vg/civcraft/mc/mercury/venus/VenusHandler.java
@@ -1,7 +1,6 @@
 package vg.civcraft.mc.mercury.venus;
 
 import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import vg.civcraft.mc.mercury.MercuryPlugin;
@@ -16,6 +15,8 @@ public class VenusHandler implements ServiceHandler{
 		service = new VenusService();
 		if (service.connected)
 			Bukkit.getScheduler().runTaskAsynchronously(plugin, service);
+		else
+			service = null;
 	}
 	
 	// Venus doesn't need to be pinged.
@@ -32,7 +33,8 @@ public class VenusHandler implements ServiceHandler{
 	@Override
 	public void sendMessage(String destination, String message, String... channels) {
 		for (String channel: channels)
-			service.sendMessage(destination, message, channel);
+			if (service != null)
+				service.sendMessage(destination, message, channel);
 	}
 
 	// Venus doesn't need channels registered.
@@ -43,7 +45,17 @@ public class VenusHandler implements ServiceHandler{
 
 	@Override
 	public void destory() {
-		service.destroy();
+		if (service != null)
+			service.destroy();
 	}
+	
+	@Override
+	public boolean isEnabled(){
+		if (service != null)
+			return true;
+		else
+			return false;
+	}
+
 
 }

--- a/src/vg/civcraft/mc/mercury/venus/VenusService.java
+++ b/src/vg/civcraft/mc/mercury/venus/VenusService.java
@@ -9,9 +9,7 @@ import java.net.UnknownHostException;
 
 import org.bukkit.Bukkit;
 
-import vg.civcraft.mc.mercury.MercuryAPI;
 import vg.civcraft.mc.mercury.MercuryConfigManager;
-import vg.civcraft.mc.mercury.MercuryPlugin;
 import vg.civcraft.mc.mercury.events.AsyncPluginBroadcastMessageEvent;
 
 public class VenusService implements Runnable{
@@ -101,6 +99,7 @@ public class VenusService implements Runnable{
 	@SuppressWarnings("deprecation")
 	@Override
 	public void run() {
+		if (connected == false){return;}
 		String recv;
 		while (connected && !socket.isClosed() && socket.isConnected()){
 			try {
@@ -121,6 +120,7 @@ public class VenusService implements Runnable{
 	public synchronized void sendMessage(String destination, String message, String plugin) {
 		// queue up message to be sent.
 		// message structure when sending is: msg,server,plugin,message
+		if (connected == false){return;}
 		output.println("msg,"+destination+","+plugin+","+message);
 		output.flush();
 	}


### PR DESCRIPTION
- Added a isEnabled method to ServiceHandler to ease detection of failed connection to server. Added stub to all Bindings.
- Added gentle self disabling when connection fails. This prevents errors in other plugins when Venus(or other) server is not found; while having other plugins still rely on just checking if mercury plugin is enabled and not also manually checking if the connection is active before doing anything.(Wizardry)
- Changed VenusService to properly check for live connection before attempting to send or receive.
